### PR TITLE
Add tests for avatar package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
+.PHONY: test
+
+fontFile=$(CURDIR)/resource/fonts/Hiragino_Sans_GB_W3.ttf
 all: install
+
+test:
+	@AVATAR_FONT=$(fontFile) go test -v ./avatar
   
 install:
 	go install github.com/holys/initials-avatar/cmd/avatar

--- a/avatar/avatar_test.go
+++ b/avatar/avatar_test.go
@@ -1,0 +1,51 @@
+package avatar
+
+import (
+	"os"
+	"testing"
+)
+
+func TestInitialsAvatar_DrawToBytes(t *testing.T) {
+	fontFile := os.Getenv("AVATAR_FONT")
+	if fontFile == "" {
+		t.Skip("Font file is needed")
+	}
+
+	av := New(fontFile)
+
+	stuffs := []struct {
+		name      string
+		size      int
+		undersize bool
+		oversize  bool
+	}{
+		{"Swordsmen", 22, true, false},
+		{"Condor Heroes", 30, false, false},
+		{"Condor Heroes", 30, false, false},
+		//		{"Condor Heroes", 200, false, true},
+	}
+
+	for _, v := range stuffs {
+		_, err := av.DrawToBytes(v.name, v.size)
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestGetInitials(t *testing.T) {
+	names := []struct {
+		full, intitials string
+	}{
+		{"David", "D"},
+		{"Goliath", "G"},
+		//		{"David Goliath", "DG"},
+	}
+
+	for _, v := range names {
+		n := getInitials(v.full)
+		if n != v.intitials {
+			t.Errorf("expected %s got %s", v.intitials, n)
+		}
+	}
+}


### PR DESCRIPTION
This add tests for the avatar package. This duplicates the font file
found in the resources/fonts to repace spaces with underscores in order
to work in nix operating systems.
