### PR TITLE
Nicer commandline application

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ b, _ := a.DrawToBytes("David", 128)
 
 ### HTTP Example
 ```
-// run it at :3000 by default. Assumes $GOBIN is in your $PATH.
+// run the http server. The port is :3000 by default. Assumes $GOBIN is in your $PATH.
 $ avatar
 
 // try it on your browser
 // http://127.0.0.1:3000/hello 
+
+// to view avaliable options
+$ avatar --help
 
 ```
 


### PR DESCRIPTION
This rewrites cmd/avatar/main.go to use codegansta/cli library. This
produce a nicer commandline application.

This is the output from running 

```
$ avatar --help
```

```
NAME:
   Initials-avatar - Generate an avatar image from a user's initials

USAGE:
   Initials-avatar [global options] command [command options] [arguments...]

VERSION:
   0.0.1

AUTHOR(S): 
   holys <chendahui007@gmail.com> 

COMMANDS:
   server, s    runs the webserver
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h       show help
   --version, -v    print the version

```

So the server can be started with

```
$ avatar server
```

Or

```
$ avatar s
```
