### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#initials-avatar
+# initials-avatar
 
 [![Build Status](https://travis-ci.org/holys/initials-avatar.svg?branch=master)](https://travis-ci.org/holys/initials-avatar)
 [![Coverage Status](https://coveralls.io/repos/holys/initials-avatar/badge.svg?branch=master&service=github)](https://coveralls.io/github/holys/initials-avatar?branch=master)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
