### PR TITLE
Set font size for images smaller or larger than 128px

### DIFF
--- a/avatar.go
+++ b/avatar.go
@@ -62,6 +62,9 @@ type Config struct {
 
 	// TrueType Font file path
 	FontFile string
+
+	// TrueType Font size
+	FontSize float64
 }
 
 // NewWithConfig provides config for LRU Cache.
@@ -69,7 +72,7 @@ func NewWithConfig(cfg Config) *InitialsAvatar {
 	var err error
 
 	avatar := new(InitialsAvatar)
-	avatar.drawer, err = newDrawer(cfg.FontFile)
+	avatar.drawer, err = newDrawer(cfg.FontFile, cfg.FontSize)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/draw.go
+++ b/draw.go
@@ -26,12 +26,12 @@ type drawer struct {
 	font        *truetype.Font
 }
 
-func newDrawer(fontFile string) (*drawer, error) {
+func newDrawer(fontFile string, fontSize float64) (*drawer, error) {
 	if fontFile == "" {
 		return nil, errFontRequired
 	}
 	g := new(drawer)
-	g.fontSize = 75.0
+	g.fontSize = fontSize
 	g.dpi = 72.0
 	g.fontHinting = font.HintingNone
 


### PR DESCRIPTION
eg.
```
        pixels := 300
	a := avatar.NewWithConfig(avatar.Config{
		FontFile: "/path/to/fontfile",
		FontSize: float64(pixels) * 75.0 / 128.0,
		MaxItems: 1024,
	})
	i, err := a.DrawToBytes(strings.ToUpper(s), pixels)
	if err != nil { ... }
```